### PR TITLE
Add EmailButton with mailto: URL

### DIFF
--- a/react-social.js
+++ b/react-social.js
@@ -174,7 +174,18 @@
     , click: function (e) {
       this.props.onClick(e);
       if (isBrowser()) {
-        window.open(this.constructUrl(), "_blank");
+        var result = this.constructUrl();
+
+        if (typeof result === "object") {
+          var url = result[0]
+          var target = result[1]
+        } else {
+          var url = result
+          var target = "_blank"
+        }
+
+        console.log("Opening URL", url, "with target", target)
+        window.open(url, target);
       }
     }
 

--- a/react-social.js
+++ b/react-social.js
@@ -263,6 +263,18 @@
     }
   });
 
+  exports.EmailButton = React.createClass({
+    mixins: [Button]
+
+    , constructUrl: function () {
+      return [
+        "mailto:?subject=" + encodeURIComponent(this.props.message)
+             + "&body=" + encodeURIComponent(this.props.url),
+        "_self"
+      ]
+    }
+  });
+
   exports.PinterestButton = React.createClass({
     mixins: [Button]
 


### PR DESCRIPTION
Requires to open in target=_self thus EmailButton's `constructUrl` returns a JS array as `[link, target]`.  Returning just a link is still supported for backwards compatibility.