### PR TITLE
Fix #35: require appId for FacebookButton

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ class App extends Component {
     let url = "https://github.com";
 
     return (
-      <FacebookButton url={url}>
+      <FacebookButton url={url} appId={appId}>
         <FacebookCount url={url} />
         {" Share " + url}
       </FacebookButton>
@@ -117,7 +117,7 @@ Url of an image.
 
 ##### appId
 
-- FacebookButton
+- FacebookButton (required)
 
 Facebook app id.
 

--- a/react-social.js
+++ b/react-social.js
@@ -391,7 +391,7 @@
       appId: React.PropTypes.oneOfType([
         React.PropTypes.string,
         React.PropTypes.number
-      ])
+      ]).isRequired
     }
 
     , constructUrl: function () {


### PR DESCRIPTION
Why:
* As a dev I like my components to throw errors when they're broken

How:
* Require prop for appId in FacebookButton component.