### PR TITLE
add facebook sharer dialog option

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Facebook app id.
 
 - FacebookButton
 
-Facebook has 2 different share dialogs. By default we're showing Feed Dialog which has more options, but supports only sharing to user's feed. You can set `sharer` option to `true` and we'll show Share Dialog where you user can choose between their feed and also pages they has access to.
+Facebook has 2 different share dialogs. By default we're showing Feed Dialog which has more options, but supports only sharing to user's feed. You can set `sharer` option to `true` and we'll show Share Dialog where you user can choose between their feed and also pages they have access to.
 
 ## Styles
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Facebook app id.
 
 - FacebookButton
 
-Facebook has 2 different share dialogs. By default we're showing Feed Dialog which has more options, but supports only sharing to user's feed. You can set `sharer` option to `true` and we'll show Share Dialog where you user can choose between their feed and also pages they have access to.
+Facebook has 2 different share dialogs. By default we're showing Feed Dialog which has more options, but supports only sharing to user's feed. You can set `sharer` option to `true` and we'll show Share Dialog where user can choose between their feed and also pages they have access to.
 
 ## Styles
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ Url of an image.
 
 Facebook app id.
 
+##### sharer
+
+- FacebookButton
+
+Facebook has 2 different share dialogs. By default we're showing Feed Dialog which has more options, but supports only sharing to user's feed. You can set `sharer` option to `true` and we'll show Share Dialog where you user can choose between their feed and also pages they has access to.
+
 ## Styles
 
 There are no styles included, the components pass all their props down

--- a/react-social.js
+++ b/react-social.js
@@ -395,6 +395,10 @@
     }
 
     , constructUrl: function () {
+      if (this.props.sharer) {
+        return "https://www.facebook.com/sharer/sharer.php?u=" + encodeURIComponent(this.props.url)
+      }
+
       return "https://www.facebook.com/dialog/feed?"
              + "app_id=" + encodeURIComponent(this.props.appId)
              + "&display=popup&caption=" + encodeURIComponent(this.props.message)


### PR DESCRIPTION
Facebook has 2 different share dialogs. By default react-social is showing **Feed Dialog** which has more options, but supports only sharing to user's feed. 

I added an option `sharer` which when set to `true` will show **Share Dialog** where user can choose between their feed and also pages they have access to.