### PR TITLE
Add picture field to query string for FacebookButton.

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ them yourself.
 * River Kanies (@riverKanies)
 * Pavel Linkesch (@orthes)
 * Vincent (@vkammerer)
+* Ryan Nevius (@rnevius)
 
 
 ---

--- a/react-social.js
+++ b/react-social.js
@@ -406,6 +406,7 @@
              + "app_id=" + encodeURIComponent(this.props.appId)
              + "&display=popup&caption=" + encodeURIComponent(this.props.message)
              + "&link=" + encodeURIComponent(this.props.url)
+             + "&picture=" + encodeURIComponent(this.props.media)
              + "&redirect_uri=" + encodeURIComponent("https://www.facebook.com/")
     }
   });


### PR DESCRIPTION
The [Facebook Feed Dialog](https://developers.facebook.com/docs/sharing/reference/feed-dialog) provides an optional `picture` field. This pull request passes the already-existing `media` prop to the `FacebookButton`, so that a preview/thumbnail image can be added to the share dialog.
