### PR TITLE
Unknown prop `sharer` on <span> tag

### DIFF
--- a/react-social.js
+++ b/react-social.js
@@ -197,6 +197,7 @@
       , target: React.PropTypes.string
       , windowOptions: React.PropTypes.array
       , _open: React.PropTypes.bool
+      , sharer: React.PropTypes.bool
     }
 
     , getDefaultProps: function () {
@@ -214,6 +215,7 @@
         , onClick: function () { }
         , windowOptions: []
         , _open: true
+        , sharer: false
       };
     }
 
@@ -228,7 +230,7 @@
     }
 
     , render: function () {
-      var other = spread(this.props, ["onClick", "element", "url", "_open", "message", "appId", "media", "windowOptions"]);
+      var other = spread(this.props, ["onClick", "element", "url", "_open", "message", "appId", "sharer", "media", "windowOptions"]);
 
       return React.createElement(
         this.props.element
@@ -394,7 +396,8 @@
       appId: React.PropTypes.oneOfType([
         React.PropTypes.string,
         React.PropTypes.number
-      ]).isRequired
+      ]).isRequired,
+      sharer: React.PropTypes.bool
     }
 
     , constructUrl: function () {


### PR DESCRIPTION
drop warning that sharer is unknown prop

import ReactSocial from 'react-social';
const { FacebookButton, TwitterButton } = ReactSocial;
<FacebookButton
            element={'span'}
            url={url}
            sharer
            className={s.fb}
            appId={sharing.facebook.app_id}
            windowOptions={['status=0', 'toolbar=0', 'width=480', 'height=350']}
          >
warning.js:36 Warning: Unknown prop sharer on tag. Remove this prop from the element. For details, see https://fb.me/react-unknown-prop