### PR TITLE
Give EmailButton a default blank target

### DIFF
--- a/react-social.js
+++ b/react-social.js
@@ -444,11 +444,7 @@
   exports.EmailButton = React.createClass({
     displayName: "EmailButton"
 
-    , mixins: [Button]
-
-    , getDefaultProps: function () {
-      return {target: "_self"};
-    }
+    , mixins: [Button, DefaultBlankTarget]
 
     , constructUrl: function () {
       return "mailto:?subject=" + encodeURIComponent(this.props.message) + "&body=" + encodeURIComponent(this.props.url);

--- a/test.js
+++ b/test.js
@@ -119,7 +119,7 @@ test("VKontakteButton", function (t) {
 });
 
 test("EmailButton", function (t) {
-  t.plan(testButton(t, "EmailButton", "_self"));
+  t.plan(testButton(t, "EmailButton"));
 });
 
 test("XingButton", function (t) {


### PR DESCRIPTION
The docs say that for the Button API, the default  ```target``` is ```_blank```. This is true for all Buttons except EmailButton, which I've fixed.